### PR TITLE
Add AgentTrace to profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://medium.com/@joe.njenga"><img src="https://img.shields.io/badge/Medium-23K%2B%20Followers-000000?style=for-the-badge&logo=medium&logoColor=white" alt="Medium"></a>
   <a href="https://newsletter.claudecodemasterclass.com/"><img src="https://img.shields.io/badge/Newsletter-70K%2B%20Subscribers-FF6719?style=for-the-badge&logo=substack&logoColor=white" alt="Newsletter"></a>
   <a href="https://github.com/Njengah/claude-code-cheat-sheet"><img src="https://img.shields.io/github/stars/Njengah/claude-code-cheat-sheet?style=for-the-badge&logo=github&label=Claude%20Code%20Cheat%20Sheet" alt="Claude Code Cheat Sheet stars"></a>
+  <a href="https://github.com/Njengah/agent-trace"><img src="https://img.shields.io/badge/AgentTrace-AI%20Agent%20Audit%20Layer-7C3AED?style=for-the-badge&logo=github&logoColor=white" alt="AgentTrace"></a>
   <a href="https://njengah.com"><img src="https://img.shields.io/badge/Website-njengah.com-2563EB?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Website"></a>
   <a href="https://njengah.com/contact"><img src="https://img.shields.io/badge/Work%20With%20Me-Contact-16A34A?style=for-the-badge" alt="Contact"></a>
 </p>
@@ -24,13 +25,15 @@ These are the best entry points into my current AI work:
 
 | Resource | Description |
 | --- | --- |
+| [AgentTrace](https://github.com/Njengah/agent-trace) | A local-first CLI for observability and audit trails of AI-assisted coding work |
+| [AgentTrace Docs](https://njengah.github.io/agent-trace/) | Beginner-friendly and technical documentation for recording AI coding evidence, reports, and workflows |
 | [400+ AI tools, testing reviews, and tutorials](https://medium.com/@joe.njenga) | My public research log for model releases, AI coding tools, automation workflows, and AI engineering patterns |
 | [Claude Code Cheat Sheet](https://github.com/Njengah/claude-code-cheat-sheet) | A practical Claude Code reference covering commands, workflows, subagents, automation, and power-user usage |
 | [Claude Code Tutorials](https://github.com/Njengah/claude-code-tutorials) | Practical demos and use cases for learning Claude Code through examples |
 | [AutoWP MCP](https://github.com/Njengah/autowpmcp) | A real MCP server that connects Claude to WordPress publishing workflows |
 | [Claude Code Masterclass](https://newsletter.claudecodemasterclass.com/) | My newsletter and course ecosystem for Claude Code, Codex, agents, and AI-native development |
 
-##  AI Engineering
+## AI Engineering
 
 I am focused on the practical discipline of AI engineering: building intelligent software systems that combine LLMs, agents, tools, automations, integrations, evaluations, and human workflows.
 
@@ -38,6 +41,7 @@ Over the last year, I have been building public authority in this space by testi
 
 | Platform / Skill | Content / Audience |
 | --- | --- |
+| AI engineering products | Building practical infrastructure for AI coding agents, starting with AgentTrace |
 | Technical writing | 400+ articles on AI, software engineering, automation, AI coding, and developer tooling |
 | Medium audience | 23K+ followers across AI and software engineering content |
 | Newsletter | 70K+ subscribers on Claude Code Masterclass |
@@ -51,13 +55,23 @@ My GitHub portfolio is built around one practical argument:
 
 > The best AI engineers do not only talk about models. They test tools, build workflows, publish working examples, evaluate failure modes, and turn lessons into reusable systems.
 
-That is the direction of this profile. My most significant AI tutorials, Medium articles, newsletter lessons, and YouTube reviews become the source material for public testing projects.
+That is the direction of this profile. My writing, newsletter, and videos are the distribution layer; the portfolio itself is becoming a set of practical AI engineering tools for developers and teams working with coding agents.
 
 ```text
-Tutorial -> Working repo -> Test workflow -> Review notes -> Article/video/course lesson
+Tool test -> Working product -> Evidence workflow -> Docs -> Article/video/course lesson
 ```
 
 This creates a portfolio that is not based on promises. It is based on repeated public experiments.
+
+## Practical AI Engineering Products
+
+These are the product-style projects that anchor my current portfolio:
+
+| Project | What It Does | Why It Matters | Status |
+| --- | --- | --- | --- |
+| [AgentTrace](https://github.com/Njengah/agent-trace) | Records AI coding tasks, Git diffs, test evidence, review notes, PR metadata, EvalOps evidence, and local dashboard reports | Gives teams an audit trail for AI-assisted coding instead of vague "the agent fixed it" claims | Public |
+| MCPGuard | Governance, approvals, policy, and audit trails for MCP tool calls | Helps teams safely connect AI agents to external tools and sensitive systems | Building next |
+| EvalOps | Benchmarks coding agents and model releases on practical engineering tasks | Turns AI tool reviews into repeatable evidence and enterprise-grade comparison reports | Planned |
 
 ## I Study, Test, & Build
 
@@ -77,6 +91,7 @@ These are the projects that currently anchor my portfolio:
 
 | Project | What It Proves | Status |
 | --- | --- | --- |
+| [AgentTrace](https://github.com/Njengah/agent-trace) | I can build practical infrastructure around AI coding agents: evidence capture, reports, PR metadata, benchmark evidence, and local dashboards | Public |
 | [Claude Code Cheat Sheet](https://github.com/Njengah/claude-code-cheat-sheet) | I test Claude Code deeply enough to document practical usage from beginner commands to advanced workflows, automation, subagents, and integrations | Public |
 | [Claude Code Tutorials](https://github.com/Njengah/claude-code-tutorials) | I turn Claude Code features into practical demos, examples, and use cases developers can learn from | Public |
 | [AutoWP MCP](https://github.com/Njengah/autowpmcp) | I can build real MCP integrations that connect Claude to external platforms, in this case WordPress content publishing | Public |
@@ -110,12 +125,16 @@ Agentic Coding        -> Claude Code, Codex, Cursor, MCP, subagents, hooks, and 
 Developer Education   -> Articles, newsletters, YouTube, courses, playbooks, and project-based learning
 ```
 
-## My Testing
+## My AI Engineering Lab
 
- I test, write about, review, and teach.
+I test tools and models, then turn the useful patterns into working projects, docs, benchmarks, and reusable workflows.
 
 | Project Direction | What It Will Demonstrate |
 | --- | --- |
+| AgentOps Infrastructure | Observability, governance, evaluation, and workflow control for AI coding agents |
+| AgentTrace | Audit trails for AI-assisted coding: task, diff, tests, reviews, PR metadata, and reports |
+| MCPGuard | Policy and approval controls for MCP servers and tool calls |
+| EvalOps | Repeatable benchmarks for AI coding tools and model releases |
 | AI Agent Starter Kit | Tool use, memory, planning, evals, traces, permissions, and production-ready agent structure |
 | MCP Server Lab | Real MCP servers for connecting coding agents to APIs, databases, files, analytics, and publishing workflows |
 | Claude Code Workflow Library | Reusable commands, subagents, hooks, project instructions, and workflow recipes |


### PR DESCRIPTION
## Summary
- Add AgentTrace
- Link AgentTrace repo and documentation from Start Here
- Add MCPGuard and EvalOps as upcoming product directions

## Validation
- Ran git diff --check before commit
- README-only change